### PR TITLE
removed redundant make param

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 COPY main.go Makefile /src/
 COPY pkg /src/pkg
 
-RUN make build CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+RUN make build CGO_ENABLED=0 GOOS=linux
 
 FROM alpine:3.17
 


### PR DESCRIPTION
Since GOARCH will be assigned inside the [Makefile](https://github.com/flant/redis-sentinel-proxy/blob/master/Makefile#L2) by default this parameter is not needed.

Moreover, now this project will be built only for AMD64, although the docker image manifest contains an ARM64 build.