### PR TITLE
Add read/write timeout for master_resolver(redisMasterFromSentinelAddr)

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 	flag.Parse()
 
 	if err := runProxying(localAddr, sentinelAddr, masterName, masterResolveRetries); err != nil {
-		log.Fatalln(err)
+		log.Fatalf("Fatal: %s", err)
 	}
 	log.Println("Exiting...")
 }
@@ -47,14 +47,13 @@ func runProxying(localAddr, sentinelAddr, masterName string, masterResolveRetrie
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error { return masterAddrResolver.UpdateMasterAddressLoop(ctx) })
 	eg.Go(func() error { return rsp.Run(ctx) })
-
 	return eg.Wait()
 }
 
 func resolveTCPAddr(addr string) *net.TCPAddr {
 	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
 	if err != nil {
-		log.Fatalf("Failed resolving tcp address: %s", err)
+		log.Fatalf("Fatal - Failed resolving tcp address: %s", err)
 	}
 	return tcpAddr
 }

--- a/pkg/master_resolver/master_resolver.go
+++ b/pkg/master_resolver/master_resolver.go
@@ -91,6 +91,7 @@ func (r *RedisMasterResolver) initialMasterAdressResolve() error {
 
 func redisMasterFromSentinelAddr(sentinelAddress *net.TCPAddr, masterName string) (*net.TCPAddr, error) {
 	conn, err := utils.TCPConnectWithTimeout(sentinelAddress.String())
+	conn.SetDeadline(time.Now().Add(time.Second))
 	if err != nil {
 		return nil, fmt.Errorf("error connecting to sentinel: %w", err)
 	}


### PR DESCRIPTION
Hello.

When i'm stopping sentinel, get stuck of funcion master_resolver.go(redisMasterFromSentinelAddr) in some cases.

After debugging, i'm realize that the problem was the timeout for reading from the connection.

My pull request is resolve this problem